### PR TITLE
プロフィール機能の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@
 @import 'form';
 @import 'flash';
 @import 'common';
+@import 'profile';
 
 html {
    word-spacing: 1px;

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -1,6 +1,6 @@
 @import './variables'; 
 
-input {
+input, select {
     &.text {
       width: 100%;
       margin: 8px 0px;

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -1,0 +1,57 @@
+@import './variables';
+
+$image_size: 56px;
+
+.profilePage {
+  margin-top: 24px;
+
+  &_user {
+    margin-bottom: 32px;
+    display: flex;
+
+    &_image {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+
+      img {
+        width: $image_size;
+        height: $image_size;
+      }
+    }
+
+    &_basicInfo {
+      margin-left: 16px;
+    }
+
+    &_actionButton {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      font-size: 12px;
+      border-radius: 4px;
+      border: 1px solid $primary-color;
+      font-weight: bold;
+      padding: 0px 8px;
+
+      a {
+        color: $primary-color;
+      }
+    }
+
+    &_name {
+      display: flex;
+      margin-bottom: 8px;
+    }
+
+    &_displayName {
+      font-size: 18px;
+      font-weight: bold;
+      margin-right: 8px;
+    }
+
+    &_introduction {
+      font-size: 12px;
+    }
+  }
+}

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,34 @@
+class ProfilesController < ApplicationController
+    before_action :authenticate_user!
+  
+    def show
+      @profile = current_user.profile
+    end
+  
+    def edit
+      @profile = current_user.profile || current_user.build_profile
+    end
+  
+    def update
+      @profile = current_user.profile || current_user.build_profile
+      @profile.assign_attributes(profile_params)
+      if @profile.save
+        redirect_to profile_path, notice: 'プロフィール更新！'
+      else
+        flash.now[:error] = '更新できませんでした'
+        render :edit
+      end
+    end
+  
+    private
+    def profile_params
+      params.require(:profile).permit(
+        :nickname,
+        :introduction,
+        :gender,
+        :birthday,
+        :subscribed,
+        :avatar
+      )
+    end
+  end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: profiles
+#
+#  id           :integer          not null, primary key
+#  birthday     :date
+#  gender       :integer
+#  introduction :text
+#  nickname     :string
+#  subscribed   :boolean          default(FALSE)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  user_id      :integer          not null
+#
+# Indexes
+#
+#  index_profiles_on_user_id  (user_id)
+#
+class Profile < ApplicationRecord
+    enum gender: {male: 0, female: 1, other: 2}
+    belongs_to :user
+    has_one_attached :avatar
+
+    def age 
+        return '不明' unless birthday.present?
+        years = Time.zone.now.year - birthday.year
+        days = Time.zone.now.yday - birthday.yday
+
+        if days < 0
+            "#{years - 1}歳"
+        else
+            "#{years}歳"
+        end
+    end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,13 +23,24 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :articles, dependent: :destroy
+  has_one :profile, dependent: :destroy
+
+  delegate :birthday, :age, :gender, to: :profile, allow_nil: true
 
   def has_written?(article)
     articles.exists?(id: article.id)
   end
 
   def display_name
-    self.email.split('@').first
+    profile&.nickname || self.email.split('@').first
+  end
+
+  def avatar_image
+    if profile&.avatar&.attached?
+      profile.avatar
+    else
+      'default-avatar.png'
+    end
   end
 
 end

--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -1,7 +1,7 @@
 .container
   = render 'tabs'
   - @articles.each do |article|
-    = render 'article', article: article
+    = render 'commons/article', article: article
   = link_to new_article_path do
     .float_btn
       %i.fa.fa-plus

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -1,7 +1,7 @@
 .article
   %h1.article_title= @article.title
   .article_detail
-    = image_tag 'default-avatar.png'
+    = image_tag @article.user.avatar_image
     %div
       %p= @article.author_name
       %p= @article.display_created_at

--- a/app/views/commons/_article.html.haml
+++ b/app/views/commons/_article.html.haml
@@ -9,7 +9,7 @@
         = image_tag 'heart.svg'
         %span 23
       .card_detail
-        = image_tag 'default-avatar.png'
+        = image_tag article.user.avatar_image
         %div
           %p= article.author_name
           %p= article.display_created_at

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -19,9 +19,9 @@
         %p.header_pageTitle BlogApp
       - if user_signed_in?
         .dropdown
-          = image_tag 'default-avatar.png', class: 'header_avatar dropbtn'
+          = image_tag current_user.avatar_image, class: 'header_avatar dropbtn'
           .dropdown-content
-            %a{:href => "#"} プロフィール
+            = link_to 'プロフィール', profile_path
             = link_to 'ログアウト', destroy_user_session_path, data: { method: 'delete' }
       - else
         = link_to 'ログイン', new_user_session_path, class: 'header_loginBtn'

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -1,0 +1,31 @@
+.container
+  %ul
+    - @profile.errors.full_messages.each do |message|
+      %li= message
+
+  = form_with(model: @profile, url: profile_path, method: 'put', local: true) do |f|
+    %div 
+      = f.label :avatar, 'アバター'
+    %div 
+      = f.file_field :avatar
+    %div
+      = f.label :nickname, 'ハンドルネーム'
+    %div
+      = f.text_field :nickname, class: 'text'
+    %div
+      = f.label :introduction, '自己紹介'
+    %div
+      = f.text_area :introduction
+    %div
+      = f.label :gender, '性別'
+    %div
+      = f.select :gender, Profile.genders.map { |k, v| [ I18n.t("enum.genders.#{k}"), k ] }, {}, { class: 'text' }
+    %div
+      = f.label :birthday, '生年月日'
+    %div
+      = f.date_field :birthday, class: 'text'
+    %div
+      = f.label :subscribed, '通知を受け取る'
+      = f.check_box :subscribed
+
+    = f.submit '保存', class: 'btn-primary'

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -1,0 +1,15 @@
+.container.profilePage
+  .profilePage_user
+    .profilePage_user_image
+      = image_tag current_user.avatar_image
+    .profilePage_user_basicInfo
+      .profilePage_user_name
+        .profilePage_user_displayName
+          #{current_user.display_name} (#{current_user.age}・#{I18n.t("enum.genders.#{current_user.gender}")})
+        .profilePage_user_actionButton
+          = link_to 'Edit', edit_profile_path
+      .profilePage_user_introduction
+        = current_user.profile&.introduction
+
+  - current_user.articles.each do |article|
+    = render 'commons/article', article: article

--- a/config/locales/enum.ja.yml
+++ b/config/locales/enum.ja.yml
@@ -1,0 +1,6 @@
+ja:
+  enum:
+    genders:
+      male: '男性'
+      female: '女性'
+      other: 'その他'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,6 @@ Rails.application.routes.draw do
     resources :comments, only: [:new, :create]
   end
 
+  resource :profile, only: [:show, :edit, :update]
+
 end

--- a/db/migrate/20211011061157_create_profiles.rb
+++ b/db/migrate/20211011061157_create_profiles.rb
@@ -1,0 +1,13 @@
+class CreateProfiles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :profiles do |t|
+      t.references :user, null: false
+      t.string :nickname
+      t.text :introduction
+      t.integer :gender
+      t.date :birthday
+      t.boolean :subscribed, default: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211011073050_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20211011073050_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_10_090747) do
+ActiveRecord::Schema.define(version: 2021_10_11_073050) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.integer "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "articles", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -29,6 +57,18 @@ ActiveRecord::Schema.define(version: 2021_10_10_090747) do
     t.index ["article_id"], name: "index_comments_on_article_id"
   end
 
+  create_table "profiles", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "nickname"
+    t.text "introduction"
+    t.integer "gender"
+    t.date "birthday"
+    t.boolean "subscribed", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -41,4 +81,6 @@ ActiveRecord::Schema.define(version: 2021_10_10_090747) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: profiles
+#
+#  id           :integer          not null, primary key
+#  birthday     :date
+#  gender       :integer
+#  introduction :text
+#  nickname     :string
+#  subscribed   :boolean          default(FALSE)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  user_id      :integer          not null
+#
+# Indexes
+#
+#  index_profiles_on_user_id  (user_id)
+#
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: profiles
+#
+#  id           :integer          not null, primary key
+#  birthday     :date
+#  gender       :integer
+#  introduction :text
+#  nickname     :string
+#  subscribed   :boolean          default(FALSE)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  user_id      :integer          not null
+#
+# Indexes
+#
+#  index_profiles_on_user_id  (user_id)
+#
+require "test_helper"
+
+class ProfileTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Profileモデルを追加 / プロフィールページを表示 / プロフィールページに記事一覧を表示 / フォームを作成 / updateアクション / プロフィールを更新 / プロフィール情報を表示 / delegateを使用 / 年齢を表示 / 性別の多言語化 / active storageの設定 / 画像アップロードと表示